### PR TITLE
비밀번호 데이터 검증 부분에서 조합 체크 오류 해결

### DIFF
--- a/src/utils/validation/common/index.test.ts
+++ b/src/utils/validation/common/index.test.ts
@@ -1,4 +1,11 @@
-import { isOnlyUseEngAndNumbers, isStartWithEng } from '.';
+import {
+  isHasLowerEng,
+  isHasNumber,
+  isHasSpecialChar,
+  isHasUpperEng,
+  isOnlyUseEngAndNumbers,
+  isStartWithEng,
+} from '.';
 
 describe('isStartWithEng() 함수 테스트', () => {
   it('영문자로 시작하면 참을 반환해야 합니다', () => {
@@ -21,5 +28,57 @@ describe('isOnlyUseEngAndNumbers() 함수 테스트', () => {
     expect(isOnlyUseEngAndNumbers('1abc@#')).toBe(false);
     expect(isOnlyUseEngAndNumbers('abc호호')).toBe(false);
     expect(isOnlyUseEngAndNumbers('abc!!')).toBe(false);
+  });
+});
+
+describe('isHasUpperEng() 함수 테스트', () => {
+  it('영대문자가 포함되어 있을 경우 참을 반환해야 합니다.', () => {
+    expect(isHasUpperEng('aefweABC')).toBe(true);
+    expect(isHasUpperEng('ABCWEFWEF')).toBe(true);
+    expect(isHasUpperEng('WEF231')).toBe(true);
+  });
+  it('영대문자가 포함되어 있지 않을 경우 거짓을 반환해야 합니다.', () => {
+    expect(isHasUpperEng('aefwe123')).toBe(false);
+    expect(isHasUpperEng('12312312#$')).toBe(false);
+    expect(isHasUpperEng('##@231')).toBe(false);
+  });
+});
+
+describe('isHasLowerEng() 함수 테스트', () => {
+  it('영소문자가 포함되어 있을 경우 참을 반환해야 합니다.', () => {
+    expect(isHasLowerEng('aefweABC')).toBe(true);
+    expect(isHasLowerEng('!3@ewfwef213')).toBe(true);
+    expect(isHasLowerEng('324wefw23')).toBe(true);
+  });
+  it('영소문자가 포함되어 있지 않을 경우 거짓을 반환해야 합니다.', () => {
+    expect(isHasLowerEng('EFWF123')).toBe(false);
+    expect(isHasLowerEng('12312312#$')).toBe(false);
+    expect(isHasLowerEng('##@231')).toBe(false);
+  });
+});
+
+describe('isHasSpecialChar() 함수 테스트', () => {
+  it('특수문자가 포함되어 있을 경우 참을 반환해야 합니다.', () => {
+    expect(isHasSpecialChar('aefweABC#@')).toBe(true);
+    expect(isHasSpecialChar('!3@ewfwef213')).toBe(true);
+    expect(isHasSpecialChar('324w#@#@efw23')).toBe(true);
+  });
+  it('특수문자가 포함되어 있지 않을 경우 거짓을 반환해야 합니다.', () => {
+    expect(isHasSpecialChar('EFWF123')).toBe(false);
+    expect(isHasSpecialChar('12312312')).toBe(false);
+    expect(isHasSpecialChar('ABC231')).toBe(false);
+  });
+});
+
+describe('isHasNumber() 함수 테스트', () => {
+  it('숫자가 포함되어 있을 경우 참을 반환해야 합니다.', () => {
+    expect(isHasNumber('aefwe123#@')).toBe(true);
+    expect(isHasNumber('!3@ewfwef213')).toBe(true);
+    expect(isHasNumber('324w#@#@efw23')).toBe(true);
+  });
+  it('숫자가 포함되어 있지 않을 경우 거짓을 반환해야 합니다.', () => {
+    expect(isHasNumber('EFW#$@##')).toBe(false);
+    expect(isHasNumber('wefwefwef')).toBe(false);
+    expect(isHasNumber('ABC(*(')).toBe(false);
   });
 });

--- a/src/utils/validation/common/index.ts
+++ b/src/utils/validation/common/index.ts
@@ -2,7 +2,24 @@ export const REG_START_ENG = /^[a-zA-Z]/;
 
 export const REG_ONLY_USE_ENG_AND_NUM = /^[a-zA-Z0-9]{0,}$/;
 
+export const REG_UPPER_ENG = /[A-Z]/;
+
+export const REG_LOWER_ENG = /[a-z]/;
+
+export const REG_SPECIAL_CHAR = /[<>{}|;:.,~!?@#$%^=&*"\\/]/;
+
+export const REG_NUM = /[0-9]/;
+
 export const isStartWithEng = (s: string): boolean => REG_START_ENG.test(s);
 
 export const isOnlyUseEngAndNumbers = (s: string): boolean =>
   REG_ONLY_USE_ENG_AND_NUM.test(s);
+
+export const isHasUpperEng = (s: string): boolean => REG_UPPER_ENG.test(s);
+
+export const isHasLowerEng = (s: string): boolean => REG_LOWER_ENG.test(s);
+
+export const isHasSpecialChar = (s: string): boolean =>
+  REG_SPECIAL_CHAR.test(s);
+
+export const isHasNumber = (s: string): boolean => REG_NUM.test(s);

--- a/src/utils/validation/pwValidation/index.test.ts
+++ b/src/utils/validation/pwValidation/index.test.ts
@@ -1,7 +1,9 @@
 import { isPwValid, pwValidator } from '.';
 
 const WARNING_PW_EMPTY = 'Please enter your password';
-const WARNING_PW_LENGTH = '`The password must be 10 ~ 35 characters long';
+const WARNING_PW_LENGTH = 'The password must be 10 ~ 35 characters long';
+const WARNING_PW_COMBINATION =
+  'The password must be a combination of at least two of uppercase and lowercase letters, numbers, and special characters.';
 
 describe('pwValidator() 함수 테스트', () => {
   it('공백문자열은 거짓과 해당하는 경고 문자열을 반환해야 합니다.', () => {
@@ -19,6 +21,26 @@ describe('pwValidator() 함수 테스트', () => {
     const result = pwValidator('1'.repeat(MAX_LENGTH + 1));
     expect(result[0]).toBe(false);
     expect(result[1]).toBe(WARNING_PW_LENGTH);
+  });
+  it('영대문자만 사용할 경우 거짓과 조합 관련 경고 문자열을 반환해야 합니다.', () => {
+    const result = pwValidator('EFWEFWEAEFWFEWFW');
+    expect(result[0]).toBe(false);
+    expect(result[1]).toBe(WARNING_PW_COMBINATION);
+  });
+  it('영소문자만 사용할 경우 거짓과 조합 관련 경고 문자열을 반환해야 합니다.', () => {
+    const result = pwValidator('abdefwefwefwefwe');
+    expect(result[0]).toBe(false);
+    expect(result[1]).toBe(WARNING_PW_COMBINATION);
+  });
+  it('숫자만 사용할 경우 거짓과 조합 관련 경고 문자열을 반환해야 합니다.', () => {
+    const result = pwValidator('12345678901');
+    expect(result[0]).toBe(false);
+    expect(result[1]).toBe(WARNING_PW_COMBINATION);
+  });
+  it('특수문자만 사용할 경우 거짓과 조합 관련 경고 문자열을 반환해야 합니다.', () => {
+    const result = pwValidator('!@!#(&(&((##$@#$');
+    expect(result[0]).toBe(false);
+    expect(result[1]).toBe(WARNING_PW_COMBINATION);
   });
   it('10 ~ 35자 사이의 영대문자 + 영소문자 조합은 참과 빈 문자열을 반환해야 합니다. ', () => {
     const result = pwValidator('ABCabcABCa');
@@ -62,6 +84,26 @@ describe('isPwValid() 함수 테스트', () => {
   it(`35자보다 길이가 길 경우 거짓을 반환해야 합니다.`, () => {
     const MAX_LENGTH = 35;
     expect(isPwValid('1'.repeat(MAX_LENGTH + 1))).toBe(false);
+  });
+  it('영대문자만 사용할 경우 거짓을 반환해야 합니다.', () => {
+    expect(isPwValid('ABCDEFGHIJ')).toBe(false);
+    expect(isPwValid('JIHGFEDCBA')).toBe(false);
+    expect(isPwValid('WEFWEFEWFF')).toBe(false);
+  });
+  it('영소문자만 사용할 경우 거짓을 반환해야 합니다.', () => {
+    expect(isPwValid('abcdefghij')).toBe(false);
+    expect(isPwValid('jihgfedcba')).toBe(false);
+    expect(isPwValid('wefwefewfw')).toBe(false);
+  });
+  it('숫자만 사용할 경우 거짓을 반환해야 합니다.', () => {
+    expect(isPwValid('1234567890')).toBe(false);
+    expect(isPwValid('0987654321')).toBe(false);
+    expect(isPwValid('1231231313')).toBe(false);
+  });
+  it('특수문자만 사용할 경우 거짓을 반환해야 합니다.', () => {
+    expect(isPwValid('^%$%^&*(*^')).toBe(false);
+    expect(isPwValid(')(*&**&^&*')).toBe(false);
+    expect(isPwValid('#@$#$%##%#')).toBe(false);
   });
   it('10 ~ 35자 사이의 영대문자 + 영소문자 조합은 참을 반환해야 합니다. ', () => {
     expect(isPwValid('ABCabcABCa')).toBe(true);

--- a/src/utils/validation/pwValidation/index.test.ts
+++ b/src/utils/validation/pwValidation/index.test.ts
@@ -1,19 +1,20 @@
-import { WARNING_PW_EMPTY, WARNING_PW_LENGTH } from '@/constants/validation';
-
 import { isPwValid, pwValidator } from '.';
 
+const WARNING_PW_EMPTY = 'Please enter your password';
+const WARNING_PW_LENGTH = '`The password must be 10 ~ 35 characters long';
+
 describe('pwValidator() 함수 테스트', () => {
-  it(`공백문자열은 거짓과 해당하는 경고 문자열을 반환해야 합니다.`, () => {
+  it('공백문자열은 거짓과 해당하는 경고 문자열을 반환해야 합니다.', () => {
     const result = pwValidator('');
     expect(result[0]).toBe(false);
     expect(result[1]).toBe(WARNING_PW_EMPTY);
   });
-  it(`10자보다 길이가 짧을 경우 거짓과 해당하는 경고 문자열을 반환해야 합니다.`, () => {
+  it('10자보다 길이가 짧을 경우 거짓과 해당하는 경고 문자열을 반환해야 합니다.', () => {
     const result = pwValidator('1');
     expect(result[0]).toBe(false);
     expect(result[1]).toBe(WARNING_PW_LENGTH);
   });
-  it(`35자보다 길이가 길 경우 거짓과 해당하는 경고 문자열을 반환해야 합니다.`, () => {
+  it('35자보다 길이가 길 경우 거짓과 해당하는 경고 문자열을 반환해야 합니다.', () => {
     const MAX_LENGTH = 35;
     const result = pwValidator('1'.repeat(MAX_LENGTH + 1));
     expect(result[0]).toBe(false);

--- a/src/utils/validation/pwValidation/index.ts
+++ b/src/utils/validation/pwValidation/index.ts
@@ -5,24 +5,21 @@ import {
   WARNING_PW_EMPTY,
   WARNING_PW_LENGTH,
 } from '@/constants/validation';
+import {
+  isHasLowerEng,
+  isHasNumber,
+  isHasSpecialChar,
+  isHasUpperEng,
+} from '../common';
 
-const specialCharsForReg = '<>{}|;:.,~!?@#$%^=&*\\"\\\\/';
-
-export const REG_PW_COMBINATION = new RegExp(
-  [
-    '^',
-    `(?=.*[A-Z])(?=.*[a-z])|`,
-    `(?=.*[A-Z])(?=.*[0-9])|`,
-    `(?=.*[A-Z])(?=.*[${specialCharsForReg}])|`,
-    `(?=.*[a-z])(?=.*[0-9])|`,
-    `(?=.*[a-z])(?=.*[${specialCharsForReg}])|`,
-    `(?=.*[0-9])(?=.*[${specialCharsForReg}])|`,
-    '$',
-  ].reduce((acc, cur) => acc + cur, ''),
-);
-
-export const isPwCombinationValid = (pw: string): boolean =>
-  REG_PW_COMBINATION.test(pw);
+export const isPwCombinationValid = (pw: string): boolean => {
+  const hasCount =
+    Number(isHasLowerEng(pw)) +
+    Number(isHasUpperEng(pw)) +
+    Number(isHasSpecialChar(pw)) +
+    Number(isHasNumber(pw));
+  return hasCount >= 2;
+};
 
 export const isPwLengthValid = (pw: string): boolean =>
   pw.length >= USER_PW_MIN_LENGTH && pw.length <= USER_PW_MAX_LENGTH;


### PR DESCRIPTION
## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->

비밀번호 조합 체크 부분 테스트 케이스를 추가하였고 해당 테스트 케이스를 통과하지 못했던 기존 코드의 오류를 수정하였습니다.

## 이슈 번호

- closes #29 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

- 비밀번호 조합 체크 관련 테스트 케이스 추가
- 영대소문자, 숫자, 특수문자 포함 여부 검증 함수 추가 및 테스트 코드 작성
- 정규식 대신 포함 여부 검증 함수를 사용하는 로직으로 변경하여 오류 수정

## 특이사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

- 새롭게 추가된 테스트 케이스가 해당 오류의 해결을 확실하게 검증하고 있는 지 확인해주세요
- 더 추가해야 할 테스트 케이스는 없는 지 확인해주세요.
- 이외 개선사항 있으시다면 편하게 말씀해주세요!