### PR TITLE
회원가입, 로그인 페이지에서 홈으로 가는 링크 추가 외 기타 작업

### DIFF
--- a/src/components/common/Jumbotron/index.tsx
+++ b/src/components/common/Jumbotron/index.tsx
@@ -8,11 +8,11 @@ type JumbotronProps = {
 };
 
 const Jumbotron: FC<JumbotronProps> = ({ title, descList }) => {
-  const isDescList = descList !== null;
+  const hasDescList = descList !== null;
 
   return (
     <div css={wrapperStyle}>
-      <h1 css={(theme) => titleStyle(theme, isDescList)}>
+      <h1 css={(theme) => titleStyle(theme, hasDescList)}>
         <span>{title}</span> to telbby
       </h1>
       {descList &&

--- a/src/components/common/Jumbotron/index.tsx
+++ b/src/components/common/Jumbotron/index.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import { wrapperStyle, titleStyle, descStyle } from './style';
+import { descStyle, titleStyle, wrapperStyle } from './style';
 
 type JumbotronProps = {
   title: string;
@@ -8,9 +8,11 @@ type JumbotronProps = {
 };
 
 const Jumbotron: FC<JumbotronProps> = ({ title, descList }) => {
+  const isDescList = descList !== null;
+
   return (
     <div css={wrapperStyle}>
-      <h1 css={titleStyle}>
+      <h1 css={(theme) => titleStyle(theme, isDescList)}>
         <span>{title}</span> to telbby
       </h1>
       {descList &&

--- a/src/components/common/Jumbotron/style.ts
+++ b/src/components/common/Jumbotron/style.ts
@@ -4,15 +4,17 @@ export const wrapperStyle = css`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 18px;
 `;
 
-export const titleStyle = (theme: Theme): SerializedStyles => css`
+export const titleStyle = (
+  theme: Theme,
+  isDesclist: boolean,
+): SerializedStyles => css`
   font-family: ${theme.fontCodingBold};
   font-size: 50px;
   text-align: center;
   color: ${theme.colorGray1};
-  margin-bottom: 10px;
+  margin-bottom: ${isDesclist ? '10px' : ''};
 
   span {
     color: ${theme.colorPrimaryDark};

--- a/src/components/common/Jumbotron/style.ts
+++ b/src/components/common/Jumbotron/style.ts
@@ -8,13 +8,13 @@ export const wrapperStyle = css`
 
 export const titleStyle = (
   theme: Theme,
-  isDesclist: boolean,
+  hasDescList: boolean,
 ): SerializedStyles => css`
   font-family: ${theme.fontCodingBold};
   font-size: 50px;
   text-align: center;
   color: ${theme.colorGray1};
-  margin-bottom: ${isDesclist ? '10px' : ''};
+  margin-bottom: ${hasDescList ? '10px' : ''};
 
   span {
     color: ${theme.colorPrimaryDark};

--- a/src/components/intro/IntroMain/index.tsx
+++ b/src/components/intro/IntroMain/index.tsx
@@ -4,7 +4,7 @@ import Shell from '@/components/Shell';
 import Jumbotron from '@/components/common/Jumbotron';
 
 import IntroSection from '../IntroSection';
-import { introMainWrapperStyle, shellWrapperStyle } from './style';
+import { introMainWrapperStyle, jumbotronWrapperStyle } from './style';
 
 const IntroMain: FC = () => {
   /**
@@ -24,23 +24,23 @@ const IntroMain: FC = () => {
   return (
     <IntroSection>
       <div css={introMainWrapperStyle}>
-        <Jumbotron
-          title="Talk"
-          descList={[
-            'Thinking about project feedback?',
-            'Here telbby will listen.',
-          ]}
-        />
+        <div css={jumbotronWrapperStyle}>
+          <Jumbotron
+            title="Talk"
+            descList={[
+              'Thinking about project feedback?',
+              'Here telbby will listen.',
+            ]}
+          />
+        </div>
         {
           /* @TODO 입력폼에 대한 기능 추가가 필요합니다 */
-          <div css={shellWrapperStyle}>
-            <Shell
-              type="service"
-              requestWhenQueryDone={requestWhenQueryDone}
-              width="789px"
-              height="208px"
-            />
-          </div>
+          <Shell
+            type="service"
+            requestWhenQueryDone={requestWhenQueryDone}
+            width="789px"
+            height="208px"
+          />
         }
       </div>
     </IntroSection>

--- a/src/components/intro/IntroMain/index.tsx
+++ b/src/components/intro/IntroMain/index.tsx
@@ -4,7 +4,7 @@ import Shell from '@/components/Shell';
 import Jumbotron from '@/components/common/Jumbotron';
 
 import IntroSection from '../IntroSection';
-import { introMainWrapperStyle } from './style';
+import { introMainWrapperStyle, shellWrapperStyle } from './style';
 
 const IntroMain: FC = () => {
   /**
@@ -33,12 +33,14 @@ const IntroMain: FC = () => {
         />
         {
           /* @TODO 입력폼에 대한 기능 추가가 필요합니다 */
-          <Shell
-            type="service"
-            requestWhenQueryDone={requestWhenQueryDone}
-            width="789px"
-            height="208px"
-          />
+          <div css={shellWrapperStyle}>
+            <Shell
+              type="service"
+              requestWhenQueryDone={requestWhenQueryDone}
+              width="789px"
+              height="208px"
+            />
+          </div>
         }
       </div>
     </IntroSection>

--- a/src/components/intro/IntroMain/style.ts
+++ b/src/components/intro/IntroMain/style.ts
@@ -7,6 +7,6 @@ export const introMainWrapperStyle = css`
   justify-content: center;
 `;
 
-export const shellWrapperStyle = css`
-  margin-top: 40px;
+export const jumbotronWrapperStyle = css`
+  margin-bottom: 40px;
 `;

--- a/src/components/intro/IntroMain/style.ts
+++ b/src/components/intro/IntroMain/style.ts
@@ -6,3 +6,7 @@ export const introMainWrapperStyle = css`
   flex-direction: column;
   justify-content: center;
 `;
+
+export const shellWrapperStyle = css`
+  margin-top: 40px;
+`;

--- a/src/pages/NotFoundPage/index.tsx
+++ b/src/pages/NotFoundPage/index.tsx
@@ -6,16 +6,16 @@ import Jumbotron from '@/components/common/Jumbotron';
 import Layout from '@/components/common/Layout';
 import Uri from '@/constants/uri';
 
-import { notFoundImageStyle, notFoundPageStyle } from './style';
+import { linkStyle, notFoundPageStyle } from './style';
 
 const NotFoundPage: FC = () => {
   return (
     <Layout>
       <div css={notFoundPageStyle}>
-        <Link to={Uri.home}>
+        <Link to={Uri.home} css={linkStyle}>
           <Jumbotron title="Back" />
         </Link>
-        <img src={notFoundImg} alt="page-not-found" css={notFoundImageStyle} />
+        <img src={notFoundImg} alt="page-not-found" />
         <p>There are no resources</p>
       </div>
     </Layout>

--- a/src/pages/NotFoundPage/index.tsx
+++ b/src/pages/NotFoundPage/index.tsx
@@ -1,12 +1,12 @@
 import React, { FC } from 'react';
 import { Link } from 'react-router-dom';
 
-import Layout from '@/components/common/Layout';
-import Jumbotron from '@/components/common/Jumbotron';
-import Uri from '@/constants/uri';
 import notFoundImg from '@/assets/images/page-not-found.png';
+import Jumbotron from '@/components/common/Jumbotron';
+import Layout from '@/components/common/Layout';
+import Uri from '@/constants/uri';
 
-import { notFoundPageStyle } from './style';
+import { notFoundImageStyle, notFoundPageStyle } from './style';
 
 const NotFoundPage: FC = () => {
   return (
@@ -15,7 +15,7 @@ const NotFoundPage: FC = () => {
         <Link to={Uri.home}>
           <Jumbotron title="Back" />
         </Link>
-        <img src={notFoundImg} alt="page-not-found" />
+        <img src={notFoundImg} alt="page-not-found" css={notFoundImageStyle} />
         <p>There are no resources</p>
       </div>
     </Layout>

--- a/src/pages/NotFoundPage/style.ts
+++ b/src/pages/NotFoundPage/style.ts
@@ -19,6 +19,6 @@ export const notFoundPageStyle = (theme: Theme): SerializedStyles => css`
   }
 `;
 
-export const notFoundImageStyle = css`
-  margin-top: 40px;
+export const linkStyle = css`
+  margin-bottom: 40px;
 `;

--- a/src/pages/NotFoundPage/style.ts
+++ b/src/pages/NotFoundPage/style.ts
@@ -18,3 +18,7 @@ export const notFoundPageStyle = (theme: Theme): SerializedStyles => css`
     margin-top: 5px;
   }
 `;
+
+export const notFoundImageStyle = css`
+  margin-top: 40px;
+`;

--- a/src/pages/ServicePage/index.tsx
+++ b/src/pages/ServicePage/index.tsx
@@ -6,7 +6,7 @@ import Layout from '@/components/common/Layout';
 import ServiceList from '@/components/service/ServiceList';
 
 import { dummy } from './dummyData';
-import { servicePageStyle, shellWrapperStyle } from './style';
+import { jumbotronWrapperStyle, servicePageStyle } from './style';
 
 const ServicePage: FC = () => {
   /**
@@ -26,15 +26,15 @@ const ServicePage: FC = () => {
   return (
     <Layout>
       <div css={servicePageStyle}>
-        <Jumbotron title="Add" />
-        <div css={shellWrapperStyle}>
-          <Shell
-            type="service"
-            requestWhenQueryDone={requestWhenQueryDone}
-            width="90%"
-            height="200px"
-          />
+        <div css={jumbotronWrapperStyle}>
+          <Jumbotron title="Add" />
         </div>
+        <Shell
+          type="service"
+          requestWhenQueryDone={requestWhenQueryDone}
+          width="90%"
+          height="200px"
+        />
         <ServiceList serviceList={dummy} />
       </div>
     </Layout>

--- a/src/pages/ServicePage/index.tsx
+++ b/src/pages/ServicePage/index.tsx
@@ -6,7 +6,7 @@ import Layout from '@/components/common/Layout';
 import ServiceList from '@/components/service/ServiceList';
 
 import { dummy } from './dummyData';
-import { servicePageStyle } from './style';
+import { servicePageStyle, shellWrapperStyle } from './style';
 
 const ServicePage: FC = () => {
   /**
@@ -27,12 +27,14 @@ const ServicePage: FC = () => {
     <Layout>
       <div css={servicePageStyle}>
         <Jumbotron title="Add" />
-        <Shell
-          type="service"
-          requestWhenQueryDone={requestWhenQueryDone}
-          width="90%"
-          height="200px"
-        />
+        <div css={shellWrapperStyle}>
+          <Shell
+            type="service"
+            requestWhenQueryDone={requestWhenQueryDone}
+            width="90%"
+            height="200px"
+          />
+        </div>
         <ServiceList serviceList={dummy} />
       </div>
     </Layout>

--- a/src/pages/ServicePage/style.ts
+++ b/src/pages/ServicePage/style.ts
@@ -4,3 +4,7 @@ export const servicePageStyle = css`
   margin-top: 80px;
   padding: 0 12%;
 `;
+
+export const shellWrapperStyle = css`
+  margin-top: 23px;
+`;

--- a/src/pages/ServicePage/style.ts
+++ b/src/pages/ServicePage/style.ts
@@ -5,6 +5,6 @@ export const servicePageStyle = css`
   padding: 0 12%;
 `;
 
-export const shellWrapperStyle = css`
-  margin-top: 23px;
+export const jumbotronWrapperStyle = css`
+  margin-bottom: 23px;
 `;

--- a/src/pages/SigninPage/index.test.tsx
+++ b/src/pages/SigninPage/index.test.tsx
@@ -1,7 +1,9 @@
+import { createMemoryHistory } from 'history';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Router } from 'react-router-dom';
 
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import SigninPage from '.';
 
@@ -12,21 +14,31 @@ describe('SigninPage 테스트', () => {
     </MemoryRouter>
   );
 
-  it(`로그인 문구를 렌더링해야 합니다.`, () => {
+  it('로그인 문구를 렌더링해야 합니다.', () => {
     render(signupPageContainer);
     expect(screen.getByRole('heading')).toHaveTextContent('Sign in to telbby');
   });
 
-  it(`로고를 렌더링해야 합니다.`, () => {
+  it('로고를 렌더링해야 합니다.', () => {
     render(signupPageContainer);
     expect(screen.getByAltText('logo'));
   });
 
-  // FIXME: #23 이 머지된 이후 테스트 케이스를 수정해야 합니다.
-  //    - href 속성 체크 => 실제로 이동이 되는지 테스트
-  it(`footer에 안내문과 함께 /signup으로 보내는 링크가 있어야 합니다.`, () => {
+  it('footer에 "Don’t have an account?" 안내문을 렌더링해야 합니다.', () => {
     render(signupPageContainer);
     expect(screen.queryByText('Don’t have an account?')).toBeInTheDocument();
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/signup');
+  });
+
+  it('Sign Up 을 클릭하면 회원가입 페이지로 이동해야 합니다.', () => {
+    const history = createMemoryHistory();
+
+    render(
+      <Router history={history}>
+        <SigninPage />
+      </Router>,
+    );
+
+    userEvent.click(screen.getByText('Sign Up'));
+    expect(history.location.pathname).toBe('/signup');
   });
 });

--- a/src/pages/SigninPage/index.tsx
+++ b/src/pages/SigninPage/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 
 import { authApi } from '@/apis';
 import Shell from '@/components/Shell';
@@ -31,10 +31,10 @@ const SigninPage: FC = () => {
   return (
     <div css={layoutStyle}>
       <header css={headerStyle}>
-        <a href="/">
+        <Link to={Uri.home}>
           <Logo onlyImg width="70px" />
           <Jumbotron title="Sign in" />
-        </a>
+        </Link>
       </header>
       <main>
         <Shell
@@ -46,7 +46,7 @@ const SigninPage: FC = () => {
       </main>
       <footer css={footerStyle}>
         <p>
-          Don’t have an account? <a href="/signup">Sign Up</a>
+          Don’t have an account? <Link to={Uri.signup}>Sign Up</Link>
         </p>
       </footer>
     </div>

--- a/src/pages/SigninPage/index.tsx
+++ b/src/pages/SigninPage/index.tsx
@@ -31,8 +31,10 @@ const SigninPage: FC = () => {
   return (
     <div css={layoutStyle}>
       <header css={headerStyle}>
-        <Logo onlyImg width="70px" />
-        <Jumbotron title="Sign in" />
+        <a href="/">
+          <Logo onlyImg width="70px" />
+          <Jumbotron title="Sign in" />
+        </a>
       </header>
       <main>
         <Shell

--- a/src/pages/SignupPage/index.test.tsx
+++ b/src/pages/SignupPage/index.test.tsx
@@ -1,7 +1,9 @@
+import { createMemoryHistory } from 'history';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Router } from 'react-router-dom';
 
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import SignupPage from '.';
 
@@ -12,21 +14,31 @@ describe('SignupPage 테스트', () => {
     </MemoryRouter>
   );
 
-  it(`회원가입 유도 문구를 렌더링해야 합니다.`, () => {
+  it('회원가입 유도 문구를 렌더링해야 합니다.', () => {
     render(signupPageContainer);
     expect(screen.getByRole('heading')).toHaveTextContent('Join to telbby');
   });
 
-  it(`로고를 렌더링해야 합니다.`, () => {
+  it('로고를 렌더링해야 합니다.', () => {
     render(signupPageContainer);
     expect(screen.getByAltText('logo'));
   });
 
-  // FIXME: #23 이 머지된 이후 테스트 케이스를 수정해야 합니다.
-  //    - href 속성 체크 => 실제로 이동이 되는지 테스트
-  it(`footer에 안내문과 함께 /signin으로 보내는 링크가 있어야 합니다.`, () => {
+  it('footer에 "Already have an account?" 안내문을 렌더링해야 합니다.', () => {
     render(signupPageContainer);
     expect(screen.queryByText('Already have an account?')).toBeInTheDocument();
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/signin');
+  });
+
+  it('Sign In 을 클릭하면 로그인 페이지로 이동해야 합니다.', () => {
+    const history = createMemoryHistory();
+
+    render(
+      <Router history={history}>
+        <SignupPage />
+      </Router>,
+    );
+
+    userEvent.click(screen.getByText('Sign In'));
+    expect(history.location.pathname).toBe('/signin');
   });
 });

--- a/src/pages/SignupPage/index.tsx
+++ b/src/pages/SignupPage/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { Link } from 'react-router-dom';
 
 import { userApi } from '@/apis';
 import Shell from '@/components/Shell';
@@ -9,6 +10,7 @@ import {
   UNEXPECTED_ERROR,
   signupError,
 } from '@/constants/error';
+import Uri from '@/constants/uri';
 import { LoginRequestBody } from '@/types';
 
 import { footerStyle, headerStyle, layoutStyle } from './style';
@@ -30,10 +32,10 @@ const SignupPage: FC = () => {
   return (
     <div css={layoutStyle}>
       <header css={headerStyle}>
-        <a href="/">
+        <Link to={Uri.home}>
           <Logo onlyImg width="70px" />
           <Jumbotron title="Join" />
-        </a>
+        </Link>
       </header>
       <main>
         <Shell
@@ -45,7 +47,7 @@ const SignupPage: FC = () => {
       </main>
       <footer css={footerStyle}>
         <p>
-          Already have an account? <a href="/signin">Sign In</a>
+          Already have an account? <Link to={Uri.signin}>Sign In</Link>
         </p>
       </footer>
     </div>

--- a/src/pages/SignupPage/index.tsx
+++ b/src/pages/SignupPage/index.tsx
@@ -30,8 +30,10 @@ const SignupPage: FC = () => {
   return (
     <div css={layoutStyle}>
       <header css={headerStyle}>
-        <Logo onlyImg width="70px" />
-        <Jumbotron title="Join" />
+        <a href="/">
+          <Logo onlyImg width="70px" />
+          <Jumbotron title="Join" />
+        </a>
       </header>
       <main>
         <Shell

--- a/src/pages/SignupPage/style.ts
+++ b/src/pages/SignupPage/style.ts
@@ -15,12 +15,17 @@ export const layoutStyle = (theme: Theme): SerializedStyles => css`
 `;
 
 export const headerStyle = css`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
   height: 160px;
   margin-bottom: 31px;
+  display: flex;
+  align-items: space-between;
+
+  a {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+  }
 `;
 
 export const footerStyle = (theme: Theme): SerializedStyles => css`


### PR DESCRIPTION
## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->

1. 회원가입, 로그인 페이지에서 홈으로 가는 링크 추가
2. 기타 오류 수정

## 이슈 번호

- closes #32 
- closes #33 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->
- `Jumbotron` 이 스타일에 영향을 줄 수 있는 요소 수정
  - `wrapperStyle` `margin-bottom` 제거
  - `titleStyle` 이 `isDescList` 를 받고 이 값이 true 이면 margin-bottom을 하도록 수정했습니다.
- `Jumbotron` 을 사용하는 페이지에서 `margin` 을 관리하도록 수정
- 회원가입, 로그인 페이지 `a` 태그 `Link` 로 수정
- 회원가입, 로그인 페이지 상단부 클릭 시 홈으로 이동하도록 수정 ( #32 )
- 회원가입, 로그인 페이지 테스트 케이스 수정 ( #33 )

## 특이사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
- 기존 `Jumbotron` 이 스타일에 영향을 주고 있어 `Signin, Signup` 페이지의 스타일이 피그마와 맞지 않았습니다.
  (이는 `feature/#32` 브랜치를 제외한 다른 브랜치에서 확인하실 수 있습니다.)
  문제성을 느껴 `Jumbotron`에서 페이지에 영향을 줄 수 있는 스타일을 수정하고, 
  이를 사용하는 측에서 관리하도록 수정했습니다.
- 기존에 signin, signup 페이지를 이동할 때 `a` 태그를 사용하고 있어 브라우저 탭이 순간적으로 `localhost:8080` 으로 바뀌는 오류가 있었습니다. `Link` 를 사용함으로써 해결했습니다.
- `#32` 를 수정하며 기존에 작성했던 테스트 코드가 a tag 관련 에러가 나게 됩니다. 
  해당 부분이 `#33` 과 영역이 겹치기 때문에, `#33` 을 반영하여 수정하게 되었습니다.